### PR TITLE
Remove fast_finish flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ env:
     - secure: "c58UgXfy+F7YJkW4bZKI82qY6GvtfKOiqyyybSon4Vrg3Xg9ZEhUFHbt/Bzaay+BwwKKoXqZww8c6WYPI6L/cPwe73iI2exHIesHMDUnhg+UOwOeM8mlwCBywePBfV3BuMH6BqeO+byAt4LEdKe+RpGCPEJY2FGc8o2MDDBcwOK4/6ydLg76ycXnduIhi74CFraHuYoW250povd/gdqNR8QMurdDsbEwr9R44rqV8EJ6P2XB8rpUuXZaiGfDYw626mIHhjUwrS34b/OeWg1+FYVuDqH2yZiYrrvt/bXlB+VPgwn9YuyTytgtWNqXVDtu54oFnllfkwGJGlcp4ra7H9E1fTqXTeggAgzk40AR8MkSn8kXJNi9EzREphNskA+wVdE1fmGbyTa2Xw5rLHK4xuFA26r6yxca0lUapdhTDknzgBdGoy2Jwk9pSyHPSIAp8th/0z54B16A5j6YkZW+UVmoa3Bk8ncFmEP4qwcKkbLiDF17icNNxyqdw56Lb9Ih15ZiUC6ZG81vWvXxZwN8dXTtDvtKGYkNRwcPtZEJq6z/nzBS3iyblKTH6FlAZr7REg23ZT5Emgr0sTwNP12oZP2Fqng4NHhvBePxFe1FjoLer9Ho/9ci0cW8LzTXzIbP/ahT1VdE5419AHtsWQF5nFlH/IfkF8X64x5gPKHAebw="
 
 matrix:
-  fast_finish: true
   include:
     - php: 5.6
       env:


### PR DESCRIPTION
It has been confirmed that the fast_finish flag is responsible for triggering multiple build notifications on #zftalk.dev.
