### PR TITLE
Port view helper from Zend View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ First stable release.
 
 ### Added
 
-- Nothing.
+- View Helper plugin [ported](https://github.com/zendframework/zend-mvc-plugin-flashmessenger/issues/3) from Zend View
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,13 @@
         "php": "^5.6 || ^7.0",
         "zendframework/zend-mvc": "^3.0",
         "zendframework/zend-session": "^2.8.5",
-        "zendframework/zend-stdlib": "^2.7 || ^3.0"
+        "zendframework/zend-stdlib": "^2.7 || ^3.0",
+        "zendframework/zend-view": "^2.10"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.4",
-        "zendframework/zend-coding-standard": "~1.0.0"
+        "zendframework/zend-coding-standard": "~1.0.0",
+        "zendframework/zend-i18n": "^2.6"
     },
     "conflict": {
         "zendframework/zend-mvc": "<3.0.0"
@@ -49,6 +51,9 @@
         "zf": {
             "component": "Zend\\Mvc\\Plugin\\FlashMessenger"
         }
+    },
+    "suggests": {
+        "zendframework/zend-i18n": "Zend\\I18n component"
     },
     "scripts": {
         "check": [

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require-dev": {
         "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.4",
         "zendframework/zend-coding-standard": "~1.0.0",
-        "zendframework/zend-i18n": "^2.6"
+        "zendframework/zend-i18n": "^2.8"
     },
     "conflict": {
         "zendframework/zend-mvc": "<3.0.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "845a247730d03148cbb58136613c7197",
+    "content-hash": "fba1dfa52e41d5d5bfdfe5002cd3331e",
     "packages": [
         {
             "name": "container-interop/container-interop",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95df8c54af88165006000f018a2d4e2d",
+    "content-hash": "845a247730d03148cbb58136613c7197",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -302,30 +302,30 @@
         },
         {
             "name": "zendframework/zend-loader",
-            "version": "2.5.1",
+            "version": "2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-loader.git",
-                "reference": "c5fd2f071bde071f4363def7dea8dec7393e135c"
+                "reference": "78f11749ea340f6ca316bca5958eef80b38f9b6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-loader/zipball/c5fd2f071bde071f4363def7dea8dec7393e135c",
-                "reference": "c5fd2f071bde071f4363def7dea8dec7393e135c",
+                "url": "https://api.github.com/repos/zendframework/zend-loader/zipball/78f11749ea340f6ca316bca5958eef80b38f9b6c",
+                "reference": "78f11749ea340f6ca316bca5958eef80b38f9b6c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.23"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.4",
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev",
-                    "dev-develop": "2.6-dev"
+                    "dev-master": "2.6.x-dev",
+                    "dev-develop": "2.7.x-dev"
                 }
             },
             "autoload": {
@@ -337,12 +337,13 @@
             "license": [
                 "BSD-3-Clause"
             ],
-            "homepage": "https://github.com/zendframework/zend-loader",
+            "description": "Autoloading and plugin loading strategies",
             "keywords": [
+                "ZendFramework",
                 "loader",
-                "zf2"
+                "zf"
             ],
-            "time": "2015-06-03T14:05:47+00:00"
+            "time": "2018-04-30T15:20:54+00:00"
         },
         {
             "name": "zendframework/zend-modulemanager",
@@ -674,31 +675,31 @@
         },
         {
             "name": "zendframework/zend-stdlib",
-            "version": "3.1.1",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-stdlib.git",
-                "reference": "10ef03144902d1955f935fff5346ed52f7d99bcc"
+                "reference": "cd164b4a18b5d1aeb69be2c26db035b5ed6925ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/10ef03144902d1955f935fff5346ed52f7d99bcc",
-                "reference": "10ef03144902d1955f935fff5346ed52f7d99bcc",
+                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/cd164b4a18b5d1aeb69be2c26db035b5ed6925ae",
+                "reference": "cd164b4a18b5d1aeb69be2c26db035b5ed6925ae",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1",
-                "phpunit/phpunit": "~4.0",
+                "phpbench/phpbench": "^0.13",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
                 "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev",
-                    "dev-develop": "3.2-dev"
+                    "dev-master": "3.2.x-dev",
+                    "dev-develop": "3.3.x-dev"
                 }
             },
             "autoload": {
@@ -710,34 +711,35 @@
             "license": [
                 "BSD-3-Clause"
             ],
-            "homepage": "https://github.com/zendframework/zend-stdlib",
+            "description": "SPL extensions, array utilities, error handlers, and more",
             "keywords": [
+                "ZendFramework",
                 "stdlib",
-                "zf2"
+                "zf"
             ],
-            "time": "2018-04-12T16:05:42+00:00"
+            "time": "2018-04-30T13:50:40+00:00"
         },
         {
             "name": "zendframework/zend-uri",
-            "version": "2.6.0",
+            "version": "2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-uri.git",
-                "reference": "fb998b9487ea8c5f4aaac0e536190709bdd5353b"
+                "reference": "3b6463645c6766f78ce537c70cb4fdabee1e725f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-uri/zipball/fb998b9487ea8c5f4aaac0e536190709bdd5353b",
-                "reference": "fb998b9487ea8c5f4aaac0e536190709bdd5353b",
+                "url": "https://api.github.com/repos/zendframework/zend-uri/zipball/3b6463645c6766f78ce537c70cb4fdabee1e725f",
+                "reference": "3b6463645c6766f78ce537c70cb4fdabee1e725f",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.6 || ^7.0",
                 "zendframework/zend-escaper": "^2.5",
-                "zendframework/zend-validator": "^2.5"
+                "zendframework/zend-validator": "^2.10"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2.1 || ^5.7.15",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.4",
                 "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "library",
@@ -756,13 +758,13 @@
             "license": [
                 "BSD-3-Clause"
             ],
-            "description": "a component that aids in manipulating and validating » Uniform Resource Identifiers (URIs)",
-            "homepage": "https://github.com/zendframework/zend-uri",
+            "description": "A component that aids in manipulating and validating » Uniform Resource Identifiers (URIs)",
             "keywords": [
+                "ZendFramework",
                 "uri",
-                "zf2"
+                "zf"
             ],
-            "time": "2018-04-10T17:08:10+00:00"
+            "time": "2018-04-30T13:40:08+00:00"
         },
         {
             "name": "zendframework/zend-validator",
@@ -1342,16 +1344,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.0.3",
+            "version": "6.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "774a82c0c5da4c1c7701790c262035d235ab7856"
+                "reference": "52187754b0eed0b8159f62a6fa30073327e8c2ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/774a82c0c5da4c1c7701790c262035d235ab7856",
-                "reference": "774a82c0c5da4c1c7701790c262035d235ab7856",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/52187754b0eed0b8159f62a6fa30073327e8c2ca",
+                "reference": "52187754b0eed0b8159f62a6fa30073327e8c2ca",
                 "shasum": ""
             },
             "require": {
@@ -1401,7 +1403,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-06T15:39:20+00:00"
+            "time": "2018-04-29T14:59:09+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1591,16 +1593,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.1.4",
+            "version": "7.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "6d51299e307dc510149e0b7cd1931dd11770e1cb"
+                "reference": "ca64dba53b88aba6af32aebc6b388068db95c435"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6d51299e307dc510149e0b7cd1931dd11770e1cb",
-                "reference": "6d51299e307dc510149e0b7cd1931dd11770e1cb",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ca64dba53b88aba6af32aebc6b388068db95c435",
+                "reference": "ca64dba53b88aba6af32aebc6b388068db95c435",
                 "shasum": ""
             },
             "require": {
@@ -1619,7 +1621,7 @@
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^2.0",
                 "phpunit/phpunit-mock-objects": "^6.1.1",
-                "sebastian/comparator": "^2.1 || ^3.0",
+                "sebastian/comparator": "^3.0",
                 "sebastian/diff": "^3.0",
                 "sebastian/environment": "^3.1",
                 "sebastian/exporter": "^3.1",
@@ -1667,7 +1669,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-18T13:41:53+00:00"
+            "time": "2018-04-29T15:09:19+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -2484,6 +2486,74 @@
                 "zf"
             ],
             "time": "2016-11-09T21:30:43+00:00"
+        },
+        {
+            "name": "zendframework/zend-i18n",
+            "version": "2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-i18n.git",
+                "reference": "cfdb658121e0d7eb969a498c2f67f1eacaab9c63"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-i18n/zipball/cfdb658121e0d7eb969a498c2f67f1eacaab9c63",
+                "reference": "cfdb658121e0d7eb969a498c2f67f1eacaab9c63",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
+                "zendframework/zend-cache": "^2.6.1",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-config": "^2.6",
+                "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
+                "zendframework/zend-filter": "^2.6.1",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+                "zendframework/zend-validator": "^2.6",
+                "zendframework/zend-view": "^2.6.3"
+            },
+            "suggest": {
+                "ext-intl": "Required for most features of Zend\\I18n; included in default builds of PHP",
+                "zendframework/zend-cache": "Zend\\Cache component",
+                "zendframework/zend-config": "Zend\\Config component",
+                "zendframework/zend-eventmanager": "You should install this package to use the events in the translator",
+                "zendframework/zend-filter": "You should install this package to use the provided filters",
+                "zendframework/zend-i18n-resources": "Translation resources",
+                "zendframework/zend-servicemanager": "Zend\\ServiceManager component",
+                "zendframework/zend-validator": "You should install this package to use the provided validators",
+                "zendframework/zend-view": "You should install this package to use the provided view helpers"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8.x-dev",
+                    "dev-develop": "2.9.x-dev"
+                },
+                "zf": {
+                    "component": "Zend\\I18n",
+                    "config-provider": "Zend\\I18n\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\I18n\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Provide translations for your application, and filter and validate internationalized values",
+            "keywords": [
+                "ZendFramework",
+                "i18n",
+                "zf"
+            ],
+            "time": "2018-04-25T19:32:43+00:00"
         }
     ],
     "aliases": [],

--- a/doc/book/flash-messenger-view-helper.md
+++ b/doc/book/flash-messenger-view-helper.md
@@ -1,0 +1,146 @@
+# FlashMessenger
+
+The `FlashMessenger` helper is used to render the messages of the
+[FlashMessenger MVC plugin](http://zendframework.github.io/zend-mvc-plugin-flashmessenger/).
+
+## Basic Usage
+
+When only using the default `namespace` for the `FlashMessenger`, you can do the
+following:
+
+```php
+// Usable in any of your .phtml files
+echo $this->flashMessenger()->render();
+```
+
+The first argument of the `render()` function is the `namespace`. If no
+`namespace` is defined, the default
+`Zend\Mvc\Controller\Plugin\FlashMessenger::NAMESPACE_DEFAULT` will be used,
+which translates to `default`.
+
+```php
+// Usable in any of your .phtml files
+echo $this->flashMessenger()->render('error');
+
+// Alternatively use one of the pre-defined namespaces 
+// (aka: use Zend\Mvc\Controller\Plugin\FlashMessenger;)
+echo $this->flashMessenger()->render(FlashMessenger::NAMESPACE_SUCCESS);
+```
+
+## CSS Layout
+
+The `FlashMessenger` default rendering adds a CSS class to the generated HTML,
+that matches the defined `namespace` that should be rendered. While it may work
+well for the default cases, every so often you may want to add specific CSS
+classes to the HTML output. This can be done while making use of the second
+parameter of the `render()` function.
+
+```php
+// Usable in any of your .phtml files
+echo $this->flashMessenger()->render('error', ['alert', 'alert-danger']);
+```
+
+The output of this example, using the default HTML rendering settings, would
+look like this:
+
+```html
+<ul class="alert alert-danger">
+    <li>Some FlashMessenger Content</li>
+    <li>You, the developer, are AWESOME!</li>
+</ul>
+```
+
+## HTML Layout
+
+Aside from modifying the rendered CSS classes of the `FlashMessenger`, you are
+furthermore able to modify the generated HTML as a whole to create even more
+distinct visuals for your flash messages. The default output format is defined
+within the source code of the `FlashMessenger` view helper itself.
+
+```php
+// Zend/View/Helper/FlashMessenger.php#L41-L43
+protected $messageCloseString     = '</li></ul>';
+protected $messageOpenFormat      = '<ul%s><li>';
+protected $messageSeparatorString = '</li><li>';
+```
+
+These defaults exactly match what we're trying to do. The placeholder `%s` will
+be filled with the CSS classes output.
+
+To change this, all we need to do is call the respective setter methods of these
+variables and give them new strings; for example:
+
+```php
+// In any of your .phtml files:
+echo $this->flashMessenger()
+    ->setMessageOpenFormat('<div%s><p>')
+    ->setMessageSeparatorString('</p><p>')
+    ->setMessageCloseString('</p></div>')
+    ->render('success');
+```
+
+The above code sample then would then generate the following output:
+
+```html
+<div class="success">
+    <p>Some FlashMessenger Content</p>
+    <p>You, who's reading the docs, are AWESOME!</p>
+</div>
+```
+
+## Sample Modification for Twitter Bootstrap 3
+
+Taking all the above knowledge into account, we can create a nice, highly usable
+and user-friendly rendering strategy using the
+[Bootstrap front-end framework](http://getbootstrap.com/) version 3 layouts:
+
+```php
+// In any of your .phtml files:
+$flash = $this->flashMessenger();
+$flash->setMessageOpenFormat('<div%s>
+    <button type="button" class="close" data-dismiss="alert" aria-hidden="true">
+        &times;
+    </button>
+    <ul><li>')
+    ->setMessageSeparatorString('</li><li>')
+    ->setMessageCloseString('</li></ul></div>');
+
+echo $flash->render('error',   array('alert', 'alert-dismissible', 'alert-danger'));
+echo $flash->render('info',    array('alert', 'alert-dismissible', 'alert-info'));
+echo $flash->render('default', array('alert', 'alert-dismissible', 'alert-warning'));
+echo $flash->render('success', array('alert', 'alert-dismissible', 'alert-success'));
+```
+
+The output of the above example would create dismissable `FlashMessages` with
+the following HTML markup. The example only covers one type of `FlashMessenger`
+output; if you would have several `FlashMessages` available in each of the
+rendered `namespaces`, then you would receive the same output multiple times
+only having different CSS classes applied.
+
+```html
+<div class="alert alert-dismissable alert-success">
+    <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
+    <ul>
+        <li>Some FlashMessenger Content</li>
+        <li>You, who's reading the docs, are AWESOME!</li>
+    </ul>
+</div>
+```
+
+## Alternative Configuration of the ViewHelper Layout
+
+`Zend\View\Helper\Service\FlashMessengerFactory` checks the application
+configuration, making it possible to set up the `FlashMessenger` strings through
+your `module.config.php`, too. The next example will set up the output to be
+identical with the above Twitter Bootstrap 3 Example
+
+```php
+'view_helper_config' => [
+    'flashmessenger' => [
+        'message_open_format'      => '<div%s><button type="button" class="close"
+data-dismiss="alert" aria-hidden="true">&times;</button><ul><li>',
+        'message_close_string'     => '</li></ul></div>',
+        'message_separator_string' => '</li><li>',
+    ],
+],
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ docs_dir: docs/book
 site_dir: docs/html
 pages:
     - index.md
+    - View Helper: flash-messenger-view-helper.md
 site_name: zend-mvc-plugin-flashmessenger
 site_description: 'zend-mvc-plugin-flashmessenger: Flash messages for zend-mvc controllers'
 repo_url: 'https://github.com/zendframework/zend-mvc-plugin-flashmessenger'

--- a/src/Module.php
+++ b/src/Module.php
@@ -7,6 +7,7 @@
 
 namespace Zend\Mvc\Plugin\FlashMessenger;
 
+use Zend\Mvc\Plugin\FlashMessenger\View;
 use Zend\ServiceManager\Factory\InvokableFactory;
 
 class Module
@@ -32,6 +33,19 @@ class Module
                     FlashMessenger::class => InvokableFactory::class,
                 ],
             ],
+            'view_helpers' => [
+                'aliases' => [
+                    'flashmessenger' => View\Helper\FlashMessenger::class,
+                    'flashMessenger' => View\Helper\FlashMessenger::class,
+                    'FlashMessenger' => View\Helper\FlashMessenger::class,
+
+                ],
+                'factories' => [
+                    View\Helper\FlashMessenger::class => View\Helper\FlashMessengerFactory::class,
+                    View\Helper\FlashMessengerFactory::class =>InvokableFactory::class,
+                    'zendviewhelperflashmessenger' => View\Helper\FlashMessengerFactory::class,
+                ]
+            ]
         ];
     }
 }

--- a/src/Module.php
+++ b/src/Module.php
@@ -42,7 +42,7 @@ class Module
                 ],
                 'factories' => [
                     View\Helper\FlashMessenger::class => View\Helper\FlashMessengerFactory::class,
-                    View\Helper\FlashMessengerFactory::class =>InvokableFactory::class,
+                    View\Helper\FlashMessengerFactory::class => InvokableFactory::class,
                     'zendviewhelperflashmessenger' => View\Helper\FlashMessengerFactory::class,
                 ]
             ]

--- a/src/View/Helper/FlashMessenger.php
+++ b/src/View/Helper/FlashMessenger.php
@@ -1,0 +1,345 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-view for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc\Plugin\FlashMessenger\View\Helper;
+
+use Zend\Mvc\Plugin\FlashMessenger\FlashMessenger as PluginFlashMessenger;
+use Zend\View\Exception\InvalidArgumentException;
+use Zend\View\Helper\AbstractHelper;
+use Zend\View\Helper\EscapeHtml;
+use Zend\View\Helper\TranslatorAwareTrait;
+
+/**
+ * Helper to proxy the plugin flash messenger
+ *
+ * Duck-types against Zend\I18n\Translator\TranslatorAwareInterface.
+ *
+ */
+class FlashMessenger extends AbstractHelper
+{
+    use TranslatorAwareTrait;
+
+    /**
+     * Default attributes for the open format tag
+     *
+     * @var array
+     */
+    protected $classMessages = [
+        'info'    => PluginFlashMessenger::NAMESPACE_INFO,
+        'error'   => PluginFlashMessenger::NAMESPACE_ERROR,
+        'success' => PluginFlashMessenger::NAMESPACE_SUCCESS,
+        'default' => PluginFlashMessenger::NAMESPACE_DEFAULT,
+        'warning' => PluginFlashMessenger::NAMESPACE_WARNING,
+    ];
+
+    /**
+     * Templates for the open/close/separators for message tags
+     *
+     * @var string
+     */
+    protected $messageCloseString     = '</li></ul>';
+    protected $messageOpenFormat      = '<ul%s><li>';
+    protected $messageSeparatorString = '</li><li>';
+
+    /**
+     * Flag whether to escape messages
+     *
+     * @var bool
+     */
+    protected $autoEscape = true;
+
+    /**
+     * Html escape helper
+     *
+     * @var EscapeHtml
+     */
+    protected $escapeHtmlHelper;
+
+    /**
+     * Flash messenger plugin
+     *
+     * @var PluginFlashMessenger
+     */
+    protected $pluginFlashMessenger;
+
+    /**
+     * Returns the flash messenger plugin controller
+     *
+     * @param  string|null $namespace
+     * @return FlashMessenger|PluginFlashMessenger
+     */
+    public function __invoke($namespace = null)
+    {
+        if (null === $namespace) {
+            return $this;
+        }
+        $flashMessenger = $this->getPluginFlashMessenger();
+
+        return $flashMessenger->getMessagesFromNamespace($namespace);
+    }
+
+    /**
+     * Proxy the flash messenger plugin controller
+     *
+     * @param  string $method
+     * @param  array  $argv
+     * @return mixed
+     */
+    public function __call($method, $argv)
+    {
+        $flashMessenger = $this->getPluginFlashMessenger();
+        return call_user_func_array([$flashMessenger, $method], $argv);
+    }
+
+    /**
+     * Render Messages
+     *
+     * @param  string    $namespace
+     * @param  array     $classes
+     * @param  null|bool $autoEscape
+     * @return string
+     */
+    public function render($namespace = 'default', array $classes = [], $autoEscape = null)
+    {
+        $flashMessenger = $this->getPluginFlashMessenger();
+        $messages = $flashMessenger->getMessagesFromNamespace($namespace);
+        return $this->renderMessages($namespace, $messages, $classes, $autoEscape);
+    }
+
+    /**
+     * Render Current Messages
+     *
+     * @param  string    $namespace
+     * @param  array     $classes
+     * @param  bool|null $autoEscape
+     * @return string
+     */
+    public function renderCurrent($namespace = 'default', array $classes = [], $autoEscape = null)
+    {
+        $flashMessenger = $this->getPluginFlashMessenger();
+        $messages = $flashMessenger->getCurrentMessagesFromNamespace($namespace);
+        return $this->renderMessages($namespace, $messages, $classes, $autoEscape);
+    }
+
+    /**
+     * Render Messages
+     *
+     * @param string    $namespace
+     * @param array     $messages
+     * @param array     $classes
+     * @param bool|null $autoEscape
+     * @return string
+     */
+    protected function renderMessages(
+        $namespace = 'default',
+        array $messages = [],
+        array $classes = [],
+        $autoEscape = null
+    ) {
+        if (empty($messages)) {
+            return '';
+        }
+
+        // Prepare classes for opening tag
+        if (empty($classes)) {
+            if (isset($this->classMessages[$namespace])) {
+                $classes = $this->classMessages[$namespace];
+            } else {
+                $classes = $this->classMessages['default'];
+            }
+            $classes = [$classes];
+        }
+
+        if (null === $autoEscape) {
+            $autoEscape = $this->getAutoEscape();
+        }
+
+        // Flatten message array
+        $escapeHtml           = $this->getEscapeHtmlHelper();
+        $messagesToPrint      = [];
+        $translator           = $this->getTranslator();
+        $translatorTextDomain = $this->getTranslatorTextDomain();
+        array_walk_recursive(
+            $messages,
+            function ($item) use (& $messagesToPrint, $escapeHtml, $autoEscape, $translator, $translatorTextDomain) {
+                if ($translator !== null) {
+                    $item = $translator->translate(
+                        $item,
+                        $translatorTextDomain
+                    );
+                }
+
+                if ($autoEscape) {
+                    $messagesToPrint[] = $escapeHtml($item);
+                    return;
+                }
+
+                $messagesToPrint[] = $item;
+            }
+        );
+
+        if (empty($messagesToPrint)) {
+            return '';
+        }
+
+        // Generate markup
+        $markup  = sprintf($this->getMessageOpenFormat(), ' class="' . implode(' ', $classes) . '"');
+        $markup .= implode(
+            sprintf($this->getMessageSeparatorString(), ' class="' . implode(' ', $classes) . '"'),
+            $messagesToPrint
+        );
+        $markup .= $this->getMessageCloseString();
+        return $markup;
+    }
+
+    /**
+     * Set whether or not auto escaping should be used
+     *
+     * @param  bool $autoEscape
+     * @return self
+     */
+    public function setAutoEscape($autoEscape = true)
+    {
+        $this->autoEscape = (bool) $autoEscape;
+        return $this;
+    }
+
+    /**
+     * Return whether auto escaping is enabled or disabled
+     *
+     * return bool
+     */
+    public function getAutoEscape()
+    {
+        return $this->autoEscape;
+    }
+
+    /**
+     * Set the string used to close message representation
+     *
+     * @param  string $messageCloseString
+     * @return FlashMessenger
+     */
+    public function setMessageCloseString($messageCloseString)
+    {
+        $this->messageCloseString = (string) $messageCloseString;
+        return $this;
+    }
+
+    /**
+     * Get the string used to close message representation
+     *
+     * @return string
+     */
+    public function getMessageCloseString()
+    {
+        return $this->messageCloseString;
+    }
+
+    /**
+     * Set the formatted string used to open message representation
+     *
+     * @param  string $messageOpenFormat
+     * @return FlashMessenger
+     */
+    public function setMessageOpenFormat($messageOpenFormat)
+    {
+        $this->messageOpenFormat = (string) $messageOpenFormat;
+        return $this;
+    }
+
+    /**
+     * Get the formatted string used to open message representation
+     *
+     * @return string
+     */
+    public function getMessageOpenFormat()
+    {
+        return $this->messageOpenFormat;
+    }
+
+    /**
+     * Set the string used to separate messages
+     *
+     * @param  string $messageSeparatorString
+     * @return FlashMessenger
+     */
+    public function setMessageSeparatorString($messageSeparatorString)
+    {
+        $this->messageSeparatorString = (string) $messageSeparatorString;
+        return $this;
+    }
+
+    /**
+     * Get the string used to separate messages
+     *
+     * @return string
+     */
+    public function getMessageSeparatorString()
+    {
+        return $this->messageSeparatorString;
+    }
+
+    /**
+     * Set the flash messenger plugin
+     *
+     * @param  PluginFlashMessenger $pluginFlashMessenger
+     * @return FlashMessenger
+     * @throws InvalidArgumentException for an invalid $pluginFlashMessenger
+     */
+    public function setPluginFlashMessenger($pluginFlashMessenger)
+    {
+        if (! $pluginFlashMessenger instanceof PluginFlashMessenger
+        ) {
+            throw new InvalidArgumentException(sprintf(
+                '%s expects a %s instance; received %s',
+                __METHOD__,
+                PluginFlashMessenger::class,
+                (is_object($pluginFlashMessenger) ? get_class($pluginFlashMessenger) : gettype($pluginFlashMessenger))
+            ));
+        }
+
+        $this->pluginFlashMessenger = $pluginFlashMessenger;
+        return $this;
+    }
+
+    /**
+     * Get the flash messenger plugin
+     *
+     * @return PluginFlashMessenger
+     */
+    public function getPluginFlashMessenger()
+    {
+        if (null === $this->pluginFlashMessenger) {
+            $this->setPluginFlashMessenger(new PluginFlashMessenger());
+        }
+
+        return $this->pluginFlashMessenger;
+    }
+
+    /**
+     * Retrieve the escapeHtml helper
+     *
+     * @return EscapeHtml
+     */
+    protected function getEscapeHtmlHelper()
+    {
+        if ($this->escapeHtmlHelper) {
+            return $this->escapeHtmlHelper;
+        }
+
+        if (method_exists($this->getView(), 'plugin')) {
+            $this->escapeHtmlHelper = $this->view->plugin('escapehtml');
+        }
+
+        if (!$this->escapeHtmlHelper instanceof EscapeHtml) {
+            $this->escapeHtmlHelper = new EscapeHtml();
+        }
+
+        return $this->escapeHtmlHelper;
+    }
+}

--- a/src/View/Helper/FlashMessenger.php
+++ b/src/View/Helper/FlashMessenger.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @link      http://github.com/zendframework/zend-view for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-mvc-plugin-flashmessenger for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-mvc-plugin-flashmessenger/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\Mvc\Plugin\FlashMessenger\View\Helper;
@@ -17,7 +17,6 @@ use Zend\View\Helper\TranslatorAwareTrait;
  * Helper to proxy the plugin flash messenger
  *
  * Duck-types against Zend\I18n\Translator\TranslatorAwareInterface.
- *
  */
 class FlashMessenger extends AbstractHelper
 {
@@ -336,7 +335,7 @@ class FlashMessenger extends AbstractHelper
             $this->escapeHtmlHelper = $this->view->plugin('escapehtml');
         }
 
-        if (!$this->escapeHtmlHelper instanceof EscapeHtml) {
+        if (! $this->escapeHtmlHelper instanceof EscapeHtml) {
             $this->escapeHtmlHelper = new EscapeHtml();
         }
 

--- a/src/View/Helper/FlashMessengerFactory.php
+++ b/src/View/Helper/FlashMessengerFactory.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-mvc-plugin-flashmessenger for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-mvc-plugin-flashmessenger/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\Mvc\Plugin\FlashMessenger\View\Helper;

--- a/src/View/Helper/FlashMessengerFactory.php
+++ b/src/View/Helper/FlashMessengerFactory.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Mvc\Plugin\FlashMessenger\View\Helper;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Factory\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class FlashMessengerFactory implements FactoryInterface
+{
+    /**
+     * Create service
+     *
+     * @param ContainerInterface $container
+     * @param string $name
+     * @param null|array $options
+     * @return FlashMessenger
+     */
+    public function __invoke(ContainerInterface $container, $name, array $options = null)
+    {
+        // test if we are using Zend\ServiceManager v2 or v3
+        if (! method_exists($container, 'configure')) {
+            $container = $container->getServiceLocator();
+        }
+        $helper                  = new FlashMessenger();
+        $controllerPluginManager = $container->get('ControllerPluginManager');
+        $flashMessenger          = $controllerPluginManager->get('flashmessenger');
+
+        $helper->setPluginFlashMessenger($flashMessenger);
+
+        $config = $container->get('config');
+        if (isset($config['view_helper_config']['flashmessenger'])) {
+            $configHelper = $config['view_helper_config']['flashmessenger'];
+            if (isset($configHelper['message_open_format'])) {
+                $helper->setMessageOpenFormat($configHelper['message_open_format']);
+            }
+            if (isset($configHelper['message_separator_string'])) {
+                $helper->setMessageSeparatorString($configHelper['message_separator_string']);
+            }
+            if (isset($configHelper['message_close_string'])) {
+                $helper->setMessageCloseString($configHelper['message_close_string']);
+            }
+        }
+
+        return $helper;
+    }
+
+    /**
+     * Create service (v2)
+     *
+     * @param ServiceLocatorInterface $container
+     * @param string $normalizedName
+     * @param string $requestedName
+     * @return FlashMessenger
+     */
+    public function createService(ServiceLocatorInterface $container, $normalizedName = null, $requestedName = null)
+    {
+        return $this($container, $requestedName);
+    }
+}

--- a/test/View/Helper/FlashMessengerTest.php
+++ b/test/View/Helper/FlashMessengerTest.php
@@ -1,0 +1,555 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Mvc\Plugin\FlashMessenger\View\Helper;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Mvc\Controller\PluginManager;
+use Zend\Mvc\Plugin\FlashMessenger\FlashMessenger as PluginFlashMessenger;
+use Zend\Mvc\Plugin\FlashMessenger\View\Helper\FlashMessenger;
+use Zend\Mvc\Plugin\FlashMessenger\View\Helper\FlashMessengerFactory;
+use Zend\ServiceManager\Config;
+use Zend\ServiceManager\Factory\InvokableFactory;
+use Zend\ServiceManager\ServiceManager;
+use Zend\View\HelperPluginManager;
+
+/**
+ * Test class for Zend\View\Helper\Cycle.
+ *
+ * @group      Zend_View
+ * @group      Zend_View_Helper
+ */
+class FlashMessengerTest extends TestCase
+{
+    private $mvcPluginClass;
+    private $plugin;
+    private $helper;
+
+    public function setUp()
+    {
+        $this->mvcPluginClass = PluginFlashMessenger::class;
+        $this->helper = new FlashMessenger();
+        $this->plugin = $this->helper->getPluginFlashMessenger();
+    }
+
+    public function seedMessages()
+    {
+        $helper = new FlashMessenger();
+        $helper->addMessage('foo');
+        $helper->addMessage('bar');
+        $helper->addInfoMessage('bar-info');
+        $helper->addSuccessMessage('bar-success');
+        $helper->addWarningMessage('bar-warning');
+        $helper->addErrorMessage('bar-error');
+        unset($helper);
+    }
+
+    public function seedCurrentMessages()
+    {
+        $helper = new FlashMessenger();
+        $helper->addMessage('foo');
+        $helper->addMessage('bar');
+        $helper->addInfoMessage('bar-info');
+        $helper->addSuccessMessage('bar-success');
+        $helper->addErrorMessage('bar-error');
+    }
+
+    public function createServiceManager(array $config = [])
+    {
+        $config = new Config([
+            'services' => [
+                'config' => $config,
+            ],
+            'factories' => [
+                'ControllerPluginManager' => function ($services, $name, $options) {
+                    return new PluginManager($services, [
+                        'aliases' => [
+                            'flashmessenger'      => $this->mvcPluginClass,
+                        ],
+                        'factories' => [
+                            $this->mvcPluginClass => InvokableFactory::class
+                        ]
+                    ]);
+                },
+                'ViewHelperManager' => function ($services, $name, $options) {
+                    return new HelperPluginManager($services, [
+                        'factories' => [
+                            'flashmessenger' => FlashMessengerFactory::class
+                        ],
+                    ]);
+                },
+            ],
+        ]);
+        $sm = new ServiceManager();
+        $config->configureServiceManager($sm);
+        return $sm;
+    }
+
+    public function testCanAssertPluginClass()
+    {
+        $this->assertEquals($this->mvcPluginClass, get_class($this->plugin));
+        $this->assertEquals($this->mvcPluginClass, get_class($this->helper->getPluginFlashMessenger()));
+        $this->assertSame($this->plugin, $this->helper->getPluginFlashMessenger());
+    }
+
+    public function testCanRetrieveMessages()
+    {
+        $helper = $this->helper;
+
+        $this->assertFalse($helper()->hasMessages());
+        $this->assertFalse($helper()->hasInfoMessages());
+        $this->assertFalse($helper()->hasSuccessMessages());
+        $this->assertFalse($helper()->hasWarningMessages());
+        $this->assertFalse($helper()->hasErrorMessages());
+
+        $this->seedMessages();
+
+        $this->assertNotEmpty($helper('default'));
+        $this->assertNotEmpty($helper('info'));
+        $this->assertNotEmpty($helper('success'));
+        $this->assertNotEmpty($helper('warning'));
+        $this->assertNotEmpty($helper('error'));
+
+        $this->assertTrue($this->plugin->hasMessages());
+        $this->assertTrue($this->plugin->hasInfoMessages());
+        $this->assertTrue($this->plugin->hasSuccessMessages());
+        $this->assertTrue($this->plugin->hasWarningMessages());
+        $this->assertTrue($this->plugin->hasErrorMessages());
+    }
+
+    public function testCanRetrieveCurrentMessages()
+    {
+        $helper = $this->helper;
+
+        $this->assertFalse($helper()->hasCurrentMessages());
+        $this->assertFalse($helper()->hasCurrentInfoMessages());
+        $this->assertFalse($helper()->hasCurrentSuccessMessages());
+        $this->assertFalse($helper()->hasCurrentErrorMessages());
+
+        $this->seedCurrentMessages();
+
+        $this->assertNotEmpty($helper('default'));
+        $this->assertNotEmpty($helper('info'));
+        $this->assertNotEmpty($helper('success'));
+        $this->assertNotEmpty($helper('error'));
+
+        $this->assertFalse($this->plugin->hasCurrentMessages());
+        $this->assertFalse($this->plugin->hasCurrentInfoMessages());
+        $this->assertFalse($this->plugin->hasCurrentSuccessMessages());
+        $this->assertFalse($this->plugin->hasCurrentErrorMessages());
+    }
+
+    public function testCanProxyAndRetrieveMessagesFromPluginController()
+    {
+        $this->assertFalse($this->helper->hasMessages());
+        $this->assertFalse($this->helper->hasInfoMessages());
+        $this->assertFalse($this->helper->hasSuccessMessages());
+        $this->assertFalse($this->helper->hasWarningMessages());
+        $this->assertFalse($this->helper->hasErrorMessages());
+
+        $this->seedMessages();
+
+        $this->assertTrue($this->helper->hasMessages());
+        $this->assertTrue($this->helper->hasInfoMessages());
+        $this->assertTrue($this->helper->hasSuccessMessages());
+        $this->assertTrue($this->helper->hasWarningMessages());
+        $this->assertTrue($this->helper->hasErrorMessages());
+    }
+
+    public function testCanProxyAndRetrieveCurrentMessagesFromPluginController()
+    {
+        $this->assertFalse($this->helper->hasCurrentMessages());
+        $this->assertFalse($this->helper->hasCurrentInfoMessages());
+        $this->assertFalse($this->helper->hasCurrentSuccessMessages());
+        $this->assertFalse($this->helper->hasCurrentErrorMessages());
+
+        $this->seedCurrentMessages();
+
+        $this->assertTrue($this->helper->hasCurrentMessages());
+        $this->assertTrue($this->helper->hasCurrentInfoMessages());
+        $this->assertTrue($this->helper->hasCurrentSuccessMessages());
+        $this->assertTrue($this->helper->hasCurrentErrorMessages());
+    }
+
+    public function testCanDisplayListOfMessages()
+    {
+        $displayInfoAssertion = '';
+        $displayInfo = $this->helper->render('info');
+        $this->assertEquals($displayInfoAssertion, $displayInfo);
+
+        $this->seedMessages();
+
+        $displayInfoAssertion = '<ul class="info"><li>bar-info</li></ul>';
+        $displayInfo = $this->helper->render('info');
+        $this->assertEquals($displayInfoAssertion, $displayInfo);
+    }
+
+    public function testCanDisplayListOfCurrentMessages()
+    {
+        $displayInfoAssertion = '';
+        $displayInfo = $this->helper->renderCurrent('info');
+        $this->assertEquals($displayInfoAssertion, $displayInfo);
+
+        $this->seedCurrentMessages();
+
+        $displayInfoAssertion = '<ul class="info"><li>bar-info</li></ul>';
+        $displayInfo = $this->helper->renderCurrent('info');
+        $this->assertEquals($displayInfoAssertion, $displayInfo);
+    }
+
+    public function testCanDisplayListOfMessagesByDefaultParameters()
+    {
+        $helper = $this->helper;
+        $this->seedMessages();
+
+        $displayInfoAssertion = '<ul class="default"><li>foo</li><li>bar</li></ul>';
+        $displayInfo = $helper()->render();
+        $this->assertEquals($displayInfoAssertion, $displayInfo);
+    }
+
+    public function testCanDisplayListOfMessagesByDefaultCurrentParameters()
+    {
+        $helper = $this->helper;
+        $this->seedCurrentMessages();
+
+        $displayInfoAssertion = '<ul class="default"><li>foo</li><li>bar</li></ul>';
+        $displayInfo = $helper()->renderCurrent();
+        $this->assertEquals($displayInfoAssertion, $displayInfo);
+    }
+
+    public function testCanDisplayListOfMessagesByInvoke()
+    {
+        $helper = $this->helper;
+        $this->seedMessages();
+
+        $displayInfoAssertion = '<ul class="info"><li>bar-info</li></ul>';
+        $displayInfo = $helper()->render('info');
+        $this->assertEquals($displayInfoAssertion, $displayInfo);
+    }
+
+    public function testCanDisplayListOfCurrentMessagesByInvoke()
+    {
+        $helper = $this->helper;
+        $this->seedCurrentMessages();
+
+        $displayInfoAssertion = '<ul class="info"><li>bar-info</li></ul>';
+        $displayInfo = $helper()->renderCurrent('info');
+        $this->assertEquals($displayInfoAssertion, $displayInfo);
+    }
+
+    public function testCanDisplayListOfMessagesCustomised()
+    {
+        $this->seedMessages();
+
+        $displayInfoAssertion = '<div class="foo-baz foo-bar"><p>bar-info</p></div>';
+        $displayInfo = $this->helper
+                ->setMessageOpenFormat('<div%s><p>')
+                ->setMessageSeparatorString('</p><p>')
+                ->setMessageCloseString('</p></div>')
+                ->render('info', ['foo-baz', 'foo-bar']);
+        $this->assertEquals($displayInfoAssertion, $displayInfo);
+    }
+
+    public function testCanDisplayListOfCurrentMessagesCustomised()
+    {
+        $this->seedCurrentMessages();
+
+        $displayInfoAssertion = '<div class="foo-baz foo-bar"><p>bar-info</p></div>';
+        $displayInfo = $this->helper
+                ->setMessageOpenFormat('<div%s><p>')
+                ->setMessageSeparatorString('</p><p>')
+                ->setMessageCloseString('</p></div>')
+                ->renderCurrent('info', ['foo-baz', 'foo-bar']);
+        $this->assertEquals($displayInfoAssertion, $displayInfo);
+    }
+
+    public function testCanDisplayListOfMessagesCustomisedSeparator()
+    {
+        $this->seedMessages();
+
+        $displayInfoAssertion = '<div><p class="foo-baz foo-bar">foo</p><p class="foo-baz foo-bar">bar</p></div>';
+        $displayInfo = $this->helper
+                ->setMessageOpenFormat('<div><p%s>')
+                ->setMessageSeparatorString('</p><p%s>')
+                ->setMessageCloseString('</p></div>')
+                ->render('default', ['foo-baz', 'foo-bar']);
+        $this->assertEquals($displayInfoAssertion, $displayInfo);
+    }
+
+    public function testCanDisplayListOfCurrentMessagesCustomisedSeparator()
+    {
+        $this->seedCurrentMessages();
+
+        $displayInfoAssertion = '<div><p class="foo-baz foo-bar">foo</p><p class="foo-baz foo-bar">bar</p></div>';
+        $displayInfo = $this->helper
+                ->setMessageOpenFormat('<div><p%s>')
+                ->setMessageSeparatorString('</p><p%s>')
+                ->setMessageCloseString('</p></div>')
+                ->renderCurrent('default', ['foo-baz', 'foo-bar']);
+        $this->assertEquals($displayInfoAssertion, $displayInfo);
+    }
+
+    public function testCanDisplayListOfMessagesCustomisedByConfig()
+    {
+        $this->seedMessages();
+
+        $config = [
+            'view_helper_config' => [
+                'flashmessenger' => [
+                    'message_open_format' => '<div%s><ul><li>',
+                    'message_separator_string' => '</li><li>',
+                    'message_close_string' => '</li></ul></div>',
+                ],
+            ],
+        ];
+
+        $services            = $this->createServiceManager($config);
+        $helperPluginManager = $services->get('ViewHelperManager');
+        $helper              = $helperPluginManager->get('flashmessenger');
+
+        $displayInfoAssertion = '<div class="info"><ul><li>bar-info</li></ul></div>';
+        $displayInfo = $helper->render('info');
+        $this->assertEquals($displayInfoAssertion, $displayInfo);
+    }
+
+    public function testCanDisplayListOfCurrentMessagesCustomisedByConfig()
+    {
+        $this->seedCurrentMessages();
+        $config = [
+            'view_helper_config' => [
+                'flashmessenger' => [
+                    'message_open_format' => '<div%s><ul><li>',
+                    'message_separator_string' => '</li><li>',
+                    'message_close_string' => '</li></ul></div>',
+                ],
+            ],
+        ];
+        $services            = $this->createServiceManager($config);
+        $helperPluginManager = $services->get('ViewHelperManager');
+        $helper              = $helperPluginManager->get('flashmessenger');
+
+        $displayInfoAssertion = '<div class="info"><ul><li>bar-info</li></ul></div>';
+        $displayInfo = $helper->renderCurrent('info');
+        $this->assertEquals($displayInfoAssertion, $displayInfo);
+    }
+
+    public function testCanDisplayListOfMessagesCustomisedByConfigSeparator()
+    {
+        $this->seedMessages();
+
+        $config = [
+            'view_helper_config' => [
+                'flashmessenger' => [
+                    'message_open_format' => '<div><ul><li%s>',
+                    'message_separator_string' => '</li><li%s>',
+                    'message_close_string' => '</li></ul></div>',
+                ],
+            ],
+        ];
+        $services            = $this->createServiceManager($config);
+        $helperPluginManager = $services->get('ViewHelperManager');
+        $helper              = $helperPluginManager->get('flashmessenger');
+
+        $displayInfoAssertion = '<div><ul><li class="foo-baz foo-bar">foo</li><li class="foo-baz foo-bar">bar</li></ul></div>';
+        $displayInfo = $helper->render('default', ['foo-baz', 'foo-bar']);
+        $this->assertEquals($displayInfoAssertion, $displayInfo);
+    }
+
+    public function testCanDisplayListOfCurrentMessagesCustomisedByConfigSeparator()
+    {
+        $this->seedCurrentMessages();
+
+        $config = [
+            'view_helper_config' => [
+                'flashmessenger' => [
+                    'message_open_format' => '<div><ul><li%s>',
+                    'message_separator_string' => '</li><li%s>',
+                    'message_close_string' => '</li></ul></div>',
+                ],
+            ],
+        ];
+        $services            = $this->createServiceManager($config);
+        $helperPluginManager = $services->get('ViewHelperManager');
+        $helper              = $helperPluginManager->get('flashmessenger');
+
+        $displayInfoAssertion = '<div><ul><li class="foo-baz foo-bar">foo</li><li class="foo-baz foo-bar">bar</li></ul></div>';
+        $displayInfo = $helper->renderCurrent('default', ['foo-baz', 'foo-bar']);
+        $this->assertEquals($displayInfoAssertion, $displayInfo);
+    }
+
+    public function testCanTranslateMessages()
+    {
+        $mockTranslator = $this->getMock('Zend\I18n\Translator\Translator');
+        $mockTranslator->expects($this->exactly(1))
+        ->method('translate')
+        ->will($this->returnValue('translated message'));
+
+        $this->helper->setTranslator($mockTranslator);
+        $this->assertTrue($this->helper->hasTranslator());
+
+        $this->seedMessages();
+
+        $displayAssertion = '<ul class="info"><li>translated message</li></ul>';
+        $display = $this->helper->render('info');
+        $this->assertEquals($displayAssertion, $display);
+    }
+
+    public function testCanTranslateCurrentMessages()
+    {
+        $mockTranslator = $this->getMock('Zend\I18n\Translator\Translator');
+        $mockTranslator->expects($this->exactly(1))
+        ->method('translate')
+        ->will($this->returnValue('translated message'));
+
+        $this->helper->setTranslator($mockTranslator);
+        $this->assertTrue($this->helper->hasTranslator());
+
+        $this->seedCurrentMessages();
+
+        $displayAssertion = '<ul class="info"><li>translated message</li></ul>';
+        $display = $this->helper->renderCurrent('info');
+        $this->assertEquals($displayAssertion, $display);
+    }
+
+    public function testAutoEscapeDefaultsToTrue()
+    {
+        $this->assertTrue($this->helper->getAutoEscape());
+    }
+
+    public function testCanSetAutoEscape()
+    {
+        $this->helper->setAutoEscape(false);
+        $this->assertFalse($this->helper->getAutoEscape());
+
+        $this->helper->setAutoEscape(true);
+        $this->assertTrue($this->helper->getAutoEscape());
+    }
+
+    /**
+     * @covers Zend\Mvc\Plugin\FlashMessenger\View\Helper\FlashMessenger::render;
+     */
+    public function testMessageIsEscapedByDefault()
+    {
+        $helper = new FlashMessenger;
+        $helper->addMessage('Foo<br />bar');
+        unset($helper);
+
+        $displayAssertion = '<ul class="default"><li>Foo&lt;br /&gt;bar</li></ul>';
+        $display = $this->helper->render('default');
+        $this->assertSame($displayAssertion, $display);
+    }
+
+    /**
+     * @covers Zend\Mvc\Plugin\FlashMessenger\View\Helper\FlashMessenger::render
+     */
+    public function testMessageIsNotEscapedWhenAutoEscapeIsFalse()
+    {
+        $helper = new FlashMessenger;
+        $helper->addMessage('Foo<br />bar');
+        unset($helper);
+
+        $displayAssertion = '<ul class="default"><li>Foo<br />bar</li></ul>';
+        $display = $this->helper->setAutoEscape(false)
+                                ->render('default');
+        $this->assertSame($displayAssertion, $display);
+    }
+
+    /**
+     * @covers Zend\Mvc\Plugin\FlashMessenger\View\Helper\FlashMessenger::render
+     */
+    public function testCanSetAutoEscapeOnRender()
+    {
+        $helper = new FlashMessenger;
+        $helper->addMessage('Foo<br />bar');
+        unset($helper);
+
+        $displayAssertion = '<ul class="default"><li>Foo<br />bar</li></ul>';
+        $display = $this->helper->render('default', [], false);
+        $this->assertSame($displayAssertion, $display);
+    }
+
+    /**
+     * @covers Zend\Mvc\Plugin\FlashMessenger\View\Helper\FlashMessenger::render
+     */
+    public function testRenderUsesCurrentAutoEscapeByDefault()
+    {
+        $helper = new FlashMessenger;
+        $helper->addMessage('Foo<br />bar');
+        unset($helper);
+
+        $this->helper->setAutoEscape(false);
+        $displayAssertion = '<ul class="default"><li>Foo<br />bar</li></ul>';
+        $display = $this->helper->render('default');
+        $this->assertSame($displayAssertion, $display);
+
+        $helper = new FlashMessenger;
+        $helper->addMessage('Foo<br />bar');
+        unset($helper);
+
+        $this->helper->setAutoEscape(true);
+        $displayAssertion = '<ul class="default"><li>Foo&lt;br /&gt;bar</li></ul>';
+        $display = $this->helper->render('default');
+        $this->assertSame($displayAssertion, $display);
+    }
+
+    /**
+     * @covers Zend\Mvc\Plugin\FlashMessenger\View\Helper\FlashMessenger::renderCurrent
+     */
+    public function testCurrentMessageIsEscapedByDefault()
+    {
+        $this->helper->addMessage('Foo<br />bar');
+
+        $displayAssertion = '<ul class="default"><li>Foo&lt;br /&gt;bar</li></ul>';
+        $display = $this->helper->renderCurrent('default');
+        $this->assertSame($displayAssertion, $display);
+    }
+
+    /**
+     * @covers Zend\Mvc\Plugin\FlashMessenger\View\Helper\FlashMessenger::renderCurrent
+     */
+    public function testCurrentMessageIsNotEscapedWhenAutoEscapeIsFalse()
+    {
+        $this->helper->addMessage('Foo<br />bar');
+
+        $displayAssertion = '<ul class="default"><li>Foo<br />bar</li></ul>';
+        $display = $this->helper->setAutoEscape(false)
+                                ->renderCurrent('default');
+        $this->assertSame($displayAssertion, $display);
+    }
+
+    /**
+     * @covers Zend\Mvc\Plugin\FlashMessenger\View\Helper\FlashMessenger::renderCurrent
+     */
+    public function testCanSetAutoEscapeOnRenderCurrent()
+    {
+        $this->helper->addMessage('Foo<br />bar');
+
+        $displayAssertion = '<ul class="default"><li>Foo<br />bar</li></ul>';
+        $display = $this->helper->renderCurrent('default', [], false);
+        $this->assertSame($displayAssertion, $display);
+    }
+
+    /**
+     * @covers Zend\Mvc\Plugin\FlashMessenger\View\Helper\FlashMessenger::renderCurrent
+     */
+    public function testRenderCurrentUsesCurrentAutoEscapeByDefault()
+    {
+        $this->helper->addMessage('Foo<br />bar');
+
+        $this->helper->setAutoEscape(false);
+        $displayAssertion = '<ul class="default"><li>Foo<br />bar</li></ul>';
+        $display = $this->helper->renderCurrent('default');
+        $this->assertSame($displayAssertion, $display);
+
+        $this->helper->setAutoEscape(true);
+        $displayAssertion = '<ul class="default"><li>Foo&lt;br /&gt;bar</li></ul>';
+        $display = $this->helper->renderCurrent('default');
+        $this->assertSame($displayAssertion, $display);
+    }
+}

--- a/test/View/Helper/FlashMessengerTest.php
+++ b/test/View/Helper/FlashMessengerTest.php
@@ -26,6 +26,7 @@ class FlashMessengerTest extends TestCase
 
     public function setUp()
     {
+        $_SESSION = [];
         $this->mvcPluginClass = PluginFlashMessenger::class;
         $this->helper = new FlashMessenger();
         $this->plugin = $this->helper->getPluginFlashMessenger();

--- a/test/View/Helper/FlashMessengerTest.php
+++ b/test/View/Helper/FlashMessengerTest.php
@@ -1,15 +1,14 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-mvc-plugin-flashmessenger for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-mvc-plugin-flashmessenger/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\Mvc\Plugin\FlashMessenger\View\Helper;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
+use Zend\I18n\Translator\Translator;
 use Zend\Mvc\Controller\PluginManager;
 use Zend\Mvc\Plugin\FlashMessenger\FlashMessenger as PluginFlashMessenger;
 use Zend\Mvc\Plugin\FlashMessenger\View\Helper\FlashMessenger;
@@ -19,12 +18,6 @@ use Zend\ServiceManager\Factory\InvokableFactory;
 use Zend\ServiceManager\ServiceManager;
 use Zend\View\HelperPluginManager;
 
-/**
- * Test class for Zend\View\Helper\Cycle.
- *
- * @group      Zend_View
- * @group      Zend_View_Helper
- */
 class FlashMessengerTest extends TestCase
 {
     private $mvcPluginClass;
@@ -70,17 +63,17 @@ class FlashMessengerTest extends TestCase
                 'ControllerPluginManager' => function ($services, $name, $options) {
                     return new PluginManager($services, [
                         'aliases' => [
-                            'flashmessenger'      => $this->mvcPluginClass,
+                            'flashmessenger' => $this->mvcPluginClass,
                         ],
                         'factories' => [
-                            $this->mvcPluginClass => InvokableFactory::class
-                        ]
+                            $this->mvcPluginClass => InvokableFactory::class,
+                        ],
                     ]);
                 },
                 'ViewHelperManager' => function ($services, $name, $options) {
                     return new HelperPluginManager($services, [
                         'factories' => [
-                            'flashmessenger' => FlashMessengerFactory::class
+                            'flashmessenger' => FlashMessengerFactory::class,
                         ],
                     ]);
                 },
@@ -249,10 +242,10 @@ class FlashMessengerTest extends TestCase
 
         $displayInfoAssertion = '<div class="foo-baz foo-bar"><p>bar-info</p></div>';
         $displayInfo = $this->helper
-                ->setMessageOpenFormat('<div%s><p>')
-                ->setMessageSeparatorString('</p><p>')
-                ->setMessageCloseString('</p></div>')
-                ->render('info', ['foo-baz', 'foo-bar']);
+            ->setMessageOpenFormat('<div%s><p>')
+            ->setMessageSeparatorString('</p><p>')
+            ->setMessageCloseString('</p></div>')
+            ->render('info', ['foo-baz', 'foo-bar']);
         $this->assertEquals($displayInfoAssertion, $displayInfo);
     }
 
@@ -262,10 +255,10 @@ class FlashMessengerTest extends TestCase
 
         $displayInfoAssertion = '<div class="foo-baz foo-bar"><p>bar-info</p></div>';
         $displayInfo = $this->helper
-                ->setMessageOpenFormat('<div%s><p>')
-                ->setMessageSeparatorString('</p><p>')
-                ->setMessageCloseString('</p></div>')
-                ->renderCurrent('info', ['foo-baz', 'foo-bar']);
+            ->setMessageOpenFormat('<div%s><p>')
+            ->setMessageSeparatorString('</p><p>')
+            ->setMessageCloseString('</p></div>')
+            ->renderCurrent('info', ['foo-baz', 'foo-bar']);
         $this->assertEquals($displayInfoAssertion, $displayInfo);
     }
 
@@ -275,10 +268,10 @@ class FlashMessengerTest extends TestCase
 
         $displayInfoAssertion = '<div><p class="foo-baz foo-bar">foo</p><p class="foo-baz foo-bar">bar</p></div>';
         $displayInfo = $this->helper
-                ->setMessageOpenFormat('<div><p%s>')
-                ->setMessageSeparatorString('</p><p%s>')
-                ->setMessageCloseString('</p></div>')
-                ->render('default', ['foo-baz', 'foo-bar']);
+            ->setMessageOpenFormat('<div><p%s>')
+            ->setMessageSeparatorString('</p><p%s>')
+            ->setMessageCloseString('</p></div>')
+            ->render('default', ['foo-baz', 'foo-bar']);
         $this->assertEquals($displayInfoAssertion, $displayInfo);
     }
 
@@ -288,10 +281,10 @@ class FlashMessengerTest extends TestCase
 
         $displayInfoAssertion = '<div><p class="foo-baz foo-bar">foo</p><p class="foo-baz foo-bar">bar</p></div>';
         $displayInfo = $this->helper
-                ->setMessageOpenFormat('<div><p%s>')
-                ->setMessageSeparatorString('</p><p%s>')
-                ->setMessageCloseString('</p></div>')
-                ->renderCurrent('default', ['foo-baz', 'foo-bar']);
+            ->setMessageOpenFormat('<div><p%s>')
+            ->setMessageSeparatorString('</p><p%s>')
+            ->setMessageCloseString('</p></div>')
+            ->renderCurrent('default', ['foo-baz', 'foo-bar']);
         $this->assertEquals($displayInfoAssertion, $displayInfo);
     }
 
@@ -356,7 +349,10 @@ class FlashMessengerTest extends TestCase
         $helperPluginManager = $services->get('ViewHelperManager');
         $helper              = $helperPluginManager->get('flashmessenger');
 
-        $displayInfoAssertion = '<div><ul><li class="foo-baz foo-bar">foo</li><li class="foo-baz foo-bar">bar</li></ul></div>';
+        $displayInfoAssertion = '<div><ul>'
+            . '<li class="foo-baz foo-bar">foo</li>'
+            . '<li class="foo-baz foo-bar">bar</li>'
+            . '</ul></div>';
         $displayInfo = $helper->render('default', ['foo-baz', 'foo-bar']);
         $this->assertEquals($displayInfoAssertion, $displayInfo);
     }
@@ -378,17 +374,21 @@ class FlashMessengerTest extends TestCase
         $helperPluginManager = $services->get('ViewHelperManager');
         $helper              = $helperPluginManager->get('flashmessenger');
 
-        $displayInfoAssertion = '<div><ul><li class="foo-baz foo-bar">foo</li><li class="foo-baz foo-bar">bar</li></ul></div>';
+        $displayInfoAssertion = '<div><ul>'
+            . '<li class="foo-baz foo-bar">foo</li>'
+            . '<li class="foo-baz foo-bar">bar</li>'
+            . '</ul></div>';
         $displayInfo = $helper->renderCurrent('default', ['foo-baz', 'foo-bar']);
         $this->assertEquals($displayInfoAssertion, $displayInfo);
     }
 
     public function testCanTranslateMessages()
     {
-        $mockTranslator = $this->getMock('Zend\I18n\Translator\Translator');
-        $mockTranslator->expects($this->exactly(1))
-        ->method('translate')
-        ->will($this->returnValue('translated message'));
+        $mockTranslator = $this->getMockBuilder(Translator::class)->getMock();
+        $mockTranslator
+            ->expects($this->exactly(1))
+            ->method('translate')
+            ->will($this->returnValue('translated message'));
 
         $this->helper->setTranslator($mockTranslator);
         $this->assertTrue($this->helper->hasTranslator());
@@ -402,10 +402,11 @@ class FlashMessengerTest extends TestCase
 
     public function testCanTranslateCurrentMessages()
     {
-        $mockTranslator = $this->getMock('Zend\I18n\Translator\Translator');
-        $mockTranslator->expects($this->exactly(1))
-        ->method('translate')
-        ->will($this->returnValue('translated message'));
+        $mockTranslator = $this->getMockBuilder(Translator::class)->getMock();
+        $mockTranslator
+            ->expects($this->exactly(1))
+            ->method('translate')
+            ->will($this->returnValue('translated message'));
 
         $this->helper->setTranslator($mockTranslator);
         $this->assertTrue($this->helper->hasTranslator());


### PR DESCRIPTION
As requested in https://github.com/zendframework/zend-mvc-plugin-flashmessenger/issues/3
Many thanks to @adamlundrigan for comprehensive checklist of tasks.

Build will most likely fail until Zend View 3 is released to satisfy new composer restrictions that prevent class name collisions.
May need feedback on naming convention of PluginFlashMessenger vs. ViewHelperFlashMessenger in import statements.

Notable changes in port are:

- no more differentiating in namespace between V2FlashMessenger and V3FlashMessenger
- implement todo section which requested usage of class constants instead strings now that code is in same repository